### PR TITLE
Remove unused class_eval on Billing::Response

### DIFF
--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -5,10 +5,6 @@ module Spree
     preference :test_mode, :boolean, :default => false
     preference :validate_on_profile_create, :boolean, :default => false
 
-    ActiveMerchant::Billing::Response.class_eval do
-      attr_writer :authorization
-    end
-
     def provider_class
       self.class
     end


### PR DESCRIPTION
As far as I can tell this hasn't been needed since 2010.
