### PR TITLE
fixes 'test' confusion between test-mode and live/test server…

### DIFF
--- a/app/models/spree/gateway/authorize_net.rb
+++ b/app/models/spree/gateway/authorize_net.rb
@@ -2,14 +2,18 @@ module Spree
   class Gateway::AuthorizeNet < Gateway
     preference :login, :string
     preference :password, :string
+    preference :server, :string, :default => "test"
 
     def provider_class
       ActiveMerchant::Billing::AuthorizeNetGateway
     end
 
     def options_with_test_preference
-      options_without_test_preference.merge(test: self.preferred_test_mode)
+      raise "You must set the 'server' preference in your payment method (Gateway::AuthorizeNet) to either 'live' or 'test'" if !['live','test'].include?(self.preferred_server)
+      # warning: 'test' parameter indicates live or test server; it DOES NOT indicate Authorize.net test-mode
+      options_without_test_preference.merge(:test => (self.preferred_server != "live") )
     end
+
     alias_method_chain :options, :test_preference
 
     def credit(amount, response_code, refund, gateway_options = {})

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -4,14 +4,19 @@ module Spree
     preference :password, :string
     preference :test_mode, :boolean, :default => false
     preference :validate_on_profile_create, :boolean, :default => false
+    preference :server, :string, :default => "test"
 
     def provider_class
       self.class
     end
 
     def options
+      raise "You must set the 'server' preference in your payment method (Gateway::AuthorizeNetCim) to either 'live' or 'test'" if !['live','test'].include?(self.preferred_server)
+
       # add :test key in the options hash, as that is what the ActiveMerchant::Billing::AuthorizeNetGateway expects
-      if self.preferred_test_mode
+      # warning: when passed to the gateway code, :test indicates live/test server; it DOES NOT indicate authorize.net test-mode
+
+      if self.preferred_server != "live"
         self.preferences[:test] = true
       else
         self.preferences.delete(:test)

--- a/spec/models/gateway/authorize_net_cim_spec.rb
+++ b/spec/models/gateway/authorize_net_cim_spec.rb
@@ -16,13 +16,13 @@ describe Spree::Gateway::AuthorizeNetCim do
   end
 
   describe 'options' do
-    it 'include :test => true when :test_mode is true' do
-      gateway.preferred_test_mode = true
+    it 'include :test => true when test server is "test"' do
+      gateway.preferred_server = "test"
       expect(gateway.options[:test]).to be true
     end
 
-    it 'does not include :test when :test_mode is false' do
-      gateway.preferred_test_mode = false
+    it 'does not include :test when test server is "live"' do
+      gateway.preferred_server = "live"
       expect(gateway.options[:test]).to be_nil
     end
   end

--- a/spec/models/gateway/authorize_net_spec.rb
+++ b/spec/models/gateway/authorize_net_spec.rb
@@ -10,14 +10,14 @@ describe Spree::Gateway::AuthorizeNet do
   end
 
   describe 'options' do
-    it 'include :test => true when :test_mode is true' do
-      gateway.preferred_test_mode = true
-      expect(gateway.options[:test]).to be true
+    it 'include :test => true when server is "test"' do
+      gateway.preferred_server = "test"
+      expect(gateway.options[:test]).to be_truthy
     end
 
-    it 'does not include :test when test_mode is false' do
-      gateway.preferred_test_mode = false
-      expect(gateway.options[:test]).to be false
+    it 'does not include :test when server is "live"' do
+      gateway.preferred_server = "live"
+      expect(gateway.options[:test]).to be_falsy
     end
   end
 end


### PR DESCRIPTION
in auth net and auth net cim code:  passing ```:test``` to gateway does not produce expected result of putting the transaction into test-mode; instead, it forces the transaction to use the test server

there is a nasty bug that will occur as a result of this backwards implementation that will manifest in a qa or staging environment -- namely, it is possible to inadvertently set 'test-mode' (NOT related to live/test server in Authorize.net or Auth.net CIM) to ON. This will mean that all transaction_ids will come back as 0, thus being impossible to capture in a auth-then-capture cycle

In other words, the old Spree interface "Test Mode" checkbox made you *think* it was enabling something called 'test mode', when in fact what it was doing was switching to the test server or the live server. 

Authorize.net 'Test mode' is actually available on both the live and test servers, in both cases it does a useless function of always returning transaction_id=0. For this reason, I recommend that you simply never use Auth.net test mode=on (in fact, sometime in Spree 2 line this was hard-coded into the codebase, this compounding the confusion of the UX labeling "Test Mode" in the admin interface)