### PR TITLE
Add a default store is in specs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   ruby:
     version: 2.1.5
+  pre:
+    - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
 test:
   pre:
     - bundle exec rake test_app

--- a/solidus_gateway.gemspec
+++ b/solidus_gateway.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "factory_girl", "~> 4.4"
   s.add_development_dependency "capybara"
-  s.add_development_dependency "poltergeist", "~> 1.5.0"
+  s.add_development_dependency "poltergeist", "~> 1.9"
   s.add_development_dependency "database_cleaner", "1.2.0"
 end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe "Stripe checkout", type: :feature do
   before do
+    FactoryGirl.create(:store)
     # Set up a zone
     zone = FactoryGirl.create(:zone)
     country = FactoryGirl.create(:country)

--- a/spec/models/gateway/stripe_gateway_spec.rb
+++ b/spec/models/gateway/stripe_gateway_spec.rb
@@ -161,7 +161,8 @@ describe Spree::Gateway::StripeGateway do
       gateway
     end
 
-    let(:order) { Spree::Order.create }
+    let!(:store) { FactoryGirl.create(:store) }
+    let(:order) { Spree::Order.create! }
 
     let(:card) do
       FactoryGirl.create(


### PR DESCRIPTION
Order now validates the presence of a store, so at least one is required to be in the database.