### PR TITLE
Set application_id attribute to Solidus

### DIFF
--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -33,6 +33,15 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::SpreedlyCoreGateway
     end
 
+    # The application_id is a class attribute on all gateways and is used to
+    # identify the "source" of the transaction. Braintree has asked us to
+    # provide this value to attribute transactions to Solidus; we do not set
+    # it on all gateways or the base gateway as other gateways' behavior with
+    # the value may differ.
+    initializer "spree.gateway.braintree_gateway.application_id" do |app|
+      ActiveMerchant::Billing::BraintreeBlueGateway.application_id = "Solidus"
+    end
+
     def self.activate
       if SpreeGateway::Engine.frontend_available?
         Rails.application.config.assets.precompile += [


### PR DESCRIPTION
In order to track payments processed by Solidus stores, Braintree requires us to pass a `:channel` parameter with the payment. The `application_id` is a class attribute on all gateways and is used to set the channel [here](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/braintree_blue.rb#L575). It is not being set on the base gateway or other gateways since their behavior with the value may be different.