### PR TITLE
Fix broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ language: ruby
 env:
   - SOLIDUS_BRANCH=v1.1   DB=mysql
   - SOLIDUS_BRANCH=v1.2   DB=mysql
+  - SOLIDUS_BRANCH=v1.3   DB=mysql
   - SOLIDUS_BRANCH=master DB=mysql
   - SOLIDUS_BRANCH=v1.1   DB=postgres
   - SOLIDUS_BRANCH=v1.2   DB=postgres
+  - SOLIDUS_BRANCH=v1.3   DB=postgres
   - SOLIDUS_BRANCH=master DB=postgres
 rvm:
   - 2.1.8

--- a/solidus_gateway.gemspec
+++ b/solidus_gateway.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", "~> 1.1"
+  s.add_dependency "activemerchant", "~> 1.48.0"
 
   s.add_development_dependency "braintree", "~> 2.0"
   s.add_development_dependency "rspec-rails", "~> 3.2"

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -212,7 +212,7 @@ describe Spree::Gateway::BraintreeGateway do
       result = @gateway.authorize(500, @credit_card)
 
       expect(result.success?).to be true
-      expect(result.authorization).to match /\A\w{6}\z/
+      expect(result.authorization).to be_present
       expect(Braintree::Transaction::Status::Authorized).to eq Braintree::Transaction.find(result.authorization).status
     end
 
@@ -223,7 +223,7 @@ describe Spree::Gateway::BraintreeGateway do
 
         @payment.process!
         expect(@payment.log_entries.size).to eq(1)
-        expect(@payment.response_code).to match /\A\w{6}\z/
+        expect(@payment.response_code).to be_present
         expect(@payment.state).to eq 'pending'
 
         transaction = ::Braintree::Transaction.find(@payment.response_code)
@@ -293,7 +293,7 @@ describe Spree::Gateway::BraintreeGateway do
     it 'do capture a previous authorization' do
       @payment.process!
       expect(@payment.log_entries.size).to eq(1)
-      expect(@payment.response_code).to match /\A\w{6}\z/
+      expect(@payment.response_code).to be_present
 
       transaction = ::Braintree::Transaction.find(@payment.response_code)
       expect(transaction.status).to eq Braintree::Transaction::Status::Authorized
@@ -326,7 +326,7 @@ describe Spree::Gateway::BraintreeGateway do
     it 'return a success response with an authorization code' do
       result =  @gateway.purchase(500, @credit_card)
       expect(result.success?).to be true
-      expect(result.authorization).to match /\A\w{6}\z/
+      expect(result.authorization).to be_present
       expect(Braintree::Transaction::Status::SubmittedForSettlement).to eq Braintree::Transaction.find(result.authorization).status
     end
 
@@ -364,7 +364,7 @@ describe Spree::Gateway::BraintreeGateway do
       @payment.process!
 
       expect(@payment.log_entries.size).to eq(1)
-      expect(@payment.response_code).to match /\A\w{6}\z/
+      expect(@payment.response_code).to be_present
 
       transaction = Braintree::Transaction.find(@payment.response_code)
       expect(transaction.status).to eq Braintree::Transaction::Status::SubmittedForSettlement
@@ -390,7 +390,7 @@ describe Spree::Gateway::BraintreeGateway do
 
     # Let's get the payment record associated with the credit
     @payment = @order.payments.last
-    expect(@payment.response_code).to match /\A\w{6}\z/
+    expect(@payment.response_code).to be_present
 
     transaction = ::Braintree::Transaction.find(@payment.response_code)
     expect(transaction.type).to eq Braintree::Transaction::Type::Credit
@@ -407,7 +407,7 @@ describe Spree::Gateway::BraintreeGateway do
     @payment.log_entries.size == 0
     @payment.process! # as done in PaymentsController#create
     @payment.log_entries.size == 1
-    expect(@payment.response_code).to match /\A\w{6}\z/
+    expect(@payment.response_code).to be_present
     expect(@payment.state).to eq 'completed'
 
     transaction = ::Braintree::Transaction.find(@payment.response_code)


### PR DESCRIPTION
The response code tests should probably be VCr'd, but the response codes are now seven
characters, probably due to how many times the test suite has ran. I'm
not even sure we need to be making assertions on this but we can tackle
that later.

Additionally the loosening on the active merchant version for 1.3 caused an issue where v1.58 of active merchant was not interface compatible so we locked the version back down here (which for some reason didn't have a dependency on activemerchant at all)