### PR TITLE
Avoid some versions of ActiveMerchant that have a Stripe bug

### DIFF
--- a/solidus_gateway.gemspec
+++ b/solidus_gateway.gemspec
@@ -24,7 +24,10 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", "~> 1.1"
-  s.add_dependency "activemerchant", "~> 1.48.0"
+
+  # ActiveMerchant v1.58 through at least v1.59 has this bug:
+  # https://github.com/activemerchant/active_merchant/pull/2098
+  s.add_dependency "activemerchant", ">= 1.48.0", "< 1.58.0"
 
   s.add_development_dependency "braintree", "~> 2.0"
   s.add_development_dependency "rspec-rails", "~> 3.2"


### PR DESCRIPTION
We could make this fancier and only exclude the bad versions if a store is actually using Stripe but I think that's probably not worth it.  I'm open to thoughts or ideas on that though.

ActiveMerchant bug: https://github.com/activemerchant/active_merchant/pull/2098