### PR TITLE
Try "trusty" on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 cache: bundler
 language: ruby
 rvm:


### PR DESCRIPTION
We have been getting SSL errors on TravisCI (works locally). Let's see if upgrading to trusty fixes this