### PR TITLE
Bump Capybara.default_max_wait_time to 10

### DIFF
--- a/solidus_gateway.gemspec
+++ b/solidus_gateway.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "factory_girl", "~> 4.4"
   s.add_development_dependency "capybara"
+  s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "poltergeist", "~> 1.9"
   s.add_development_dependency "database_cleaner", "1.2.0"
 end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe "Stripe checkout", type: :feature do
     click_link "DL-44"
     click_button "Add To Cart"
 
+    expect(page).to have_current_path("/cart")
     click_button "Checkout"
 
     # Address
+    expect(page).to have_current_path("/checkout/address")
     fill_in "Customer E-Mail", with: "han@example.com"
     within("#billing") do
       fill_in "First Name", with: "Han"
@@ -38,6 +40,7 @@ RSpec.describe "Stripe checkout", type: :feature do
     click_on "Save and Continue"
 
     # Delivery
+    expect(page).to have_current_path("/checkout/delivery")
     click_on "Save and Continue"
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ Capybara.register_driver(:poltergeist) do |app|
   Capybara::Poltergeist::Driver.new app, timeout: 90
 end
 Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 10
 
 require "database_cleaner"
 require "braintree"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rspec/rails"
 
 require "capybara/rspec"
+require 'capybara-screenshot/rspec'
 require 'capybara/poltergeist'
 Capybara.register_driver(:poltergeist) do |app|
   Capybara::Poltergeist::Driver.new app, timeout: 90


### PR DESCRIPTION
We are getting occasional spurious failures on TravisCI. Since this
suite makes external HTTP requests, we should use a value larger than
the default 2