### PR TITLE
Fix stripe checkout spec

### DIFF
--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe "Stripe checkout", type: :feature do
   it "shows an error with invalid security fields", js: true do
     fill_in "Card Number", with: "4242 4242 4242 4242"
     fill_in "Expiration", with: "01 / #{Time.now.year + 1}"
+    fill_in "Card Code", with: "12"
     click_button "Save and Continue"
     expect(page).to have_content("Your card's security code is invalid.")
   end


### PR DESCRIPTION
Something changed causing stripe to ignore the blank CVV code. Changing it to a two digit number gets the result we expect.

This is the recommendation in the stripe docs https://stripe.com/docs/testing#cards