### PR TITLE
Add support for Stripe's statement descriptor field

### DIFF
--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -85,6 +85,10 @@ module Spree
       options[:description] = "Spree Order ID: #{gateway_options[:order_id]}"
       options[:currency] = gateway_options[:currency]
 
+      # The Stripe ActiveMerchant gateway accepts a key named statement_description to set statement_descriptor
+      # The maximum length of the statement descriptor is 22 characters.
+      options[:statement_description] = options[:description][0..21]
+
       if customer = creditcard.gateway_customer_profile_id
         options[:customer] = customer
       end


### PR DESCRIPTION
This PR just duplicates the first 22 characters of the `description` option as the `statement_description`. This is supported by the ActiveMerchant Stripe gateway.

https://stripe.com/docs/api#create_charge
> An arbitrary string to be displayed on your customer's credit card statement. This may be up to 22 characters.
