### PR TITLE
Create existing_payment/_stripe.html.erb

### DIFF
--- a/lib/views/frontend/spree/checkout/existing_payment/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/existing_payment/_stripe.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "spree/checkout/existing_payment/gateway", locals: { wallet_payment_source: wallet_payment_source, default: default } %>


### PR DESCRIPTION
As described in https://github.com/solidusio/solidus_gateway/issues/48, Solidus 2.2 created the need for views in the `existing_payment` folder, but no such views exist in `solidus_gateway`. This created issues where customers could not checkout using `solidus_gateway` methods (in our case, Stripe).

This PR creates a primitive `_stripe` view which just renders the default gateway view. Nothing special, but it should fix this issue.

This _may_ also fix https://github.com/solidusio/solidus_gateway/issues/30 as well, depending on what exactly was the root cause of that.