### PR TITLE
Replace before_filter with before_action

### DIFF
--- a/lib/controllers/frontend/spree/checkout_controller_decorator.rb
+++ b/lib/controllers/frontend/spree/checkout_controller_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   CheckoutController.class_eval do
-    before_filter :confirm_skrill, :only => [:update]
+    before_action :confirm_skrill, :only => [:update]
 
     def skrill_return
 


### PR DESCRIPTION
`before_filter` has been deprecated in Rails 5.1