### PR TITLE
Remove cruft from engine.rb

### DIFF
--- a/lib/assets/javascripts/spree/frontend/solidus_gateway.js
+++ b/lib/assets/javascripts/spree/frontend/solidus_gateway.js
@@ -1,1 +1,0 @@
-//= require spree/frontend

--- a/lib/assets/stylesheets/spree/frontend/solidus_gateway.css
+++ b/lib/assets/stylesheets/spree/frontend/solidus_gateway.css
@@ -1,3 +1,0 @@
-/*
- *= require spree/frontend
-*/

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -45,15 +45,6 @@ module SpreeGateway
       end
     end
 
-    def self.activate
-      if SpreeGateway::Engine.frontend_available?
-        Rails.application.config.assets.precompile += [
-          'lib/assets/javascripts/spree/frontend/solidus_gateway.js',
-          'lib/assets/javascripts/spree/frontend/solidus_gateway.css',
-        ]
-      end
-    end
-
     def self.backend_available?
       @@backend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Backend::Engine')
     end
@@ -69,7 +60,5 @@ module SpreeGateway
     if self.frontend_available?
       paths["app/views"] << "lib/views/frontend"
     end
-
-    config.to_prepare &method(:activate).to_proc
   end
 end

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -43,19 +43,11 @@ module SpreeGateway
       end
     end
 
-    def self.backend_available?
-      @@backend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Backend::Engine')
-    end
-
-    def self.frontend_available?
-      @@frontend_available ||= ::Rails::Engine.subclasses.map(&:instance).map{ |e| e.class.to_s }.include?('Spree::Frontend::Engine')
-    end
-
-    if self.backend_available?
+    if SolidusSupport.backend_available?
       paths["app/views"] << "lib/views/backend"
     end
 
-    if self.frontend_available?
+    if SolidusSupport.frontend_available?
       paths["app/views"] << "lib/views/frontend"
     end
   end

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -2,8 +2,6 @@ module SpreeGateway
   class Engine < Rails::Engine
     engine_name 'solidus_gateway'
 
-    config.autoload_paths += %W(#{config.root}/lib)
-
     initializer "spree.gateway.payment_methods", :after => "spree.register.payment_methods" do |app|
         app.config.spree.payment_methods << Spree::Gateway::AuthorizeNetCim
         app.config.spree.payment_methods << Spree::Gateway::AuthorizeNet

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -38,7 +38,7 @@ module SpreeGateway
     initializer "spree.gateway.braintree_gateway.application_id" do |app|
       # NOTE: if the braintree gem is not loaded, calling ActiveMerchant::Billing::BraintreeBlueGateway crashes
       # therefore, check here to see if Braintree exists before trying to call it
-      if defined?(Braintree) 
+      if defined?(Braintree)
         ActiveMerchant::Billing::BraintreeBlueGateway.application_id = "Solidus"
       end
     end

--- a/solidus_gateway.gemspec
+++ b/solidus_gateway.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", [">= 1.1", "< 3"]
-  s.add_dependency "solidus_support"
+  s.add_dependency "solidus_support", ">= 0.1.2"
 
   # ActiveMerchant v1.58 through v1.59 introduced a breaking change
   # to the stripe gateway.


### PR DESCRIPTION
Partly because we no longer have controllers, we don't need much of the configuration in `engine.rb`:

* Remove assets, which were effectively empty files (other than including frontend js/css)
* Remove lib from autoload paths
* Use *_available? from solidus_support