### PR TITLE
Remove duplicated Spree::Gateway::UsaEpay in engine.rb

### DIFF
--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -20,7 +20,6 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::UsaEpay
         app.config.spree.payment_methods << Spree::Gateway::BalancedGateway
         app.config.spree.payment_methods << Spree::Gateway::DataCash
-        app.config.spree.payment_methods << Spree::Gateway::UsaEpay
         app.config.spree.payment_methods << Spree::Gateway::PinGateway
         app.config.spree.payment_methods << Spree::Gateway::Paymill
         app.config.spree.payment_methods << Spree::Gateway::PayflowPro


### PR DESCRIPTION
Spree::Gateway::UsaEpay was included two times in engine.rb

Resolve https://github.com/solidusio/solidus_gateway/issues/38