### PR TITLE
add ffaker to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'mysql2'
 
 group :development, :test do
   gem "pry-rails"
+  gem "ffaker"
 end
 
 gemspec


### PR DESCRIPTION
Since this [commit](https://github.com/solidusio/solidus/commit/53af716f6037137ff4fd9abf147d41cf5e060733) `ffaker` isn't a dependency in core and is causing an error in master build.