### PR TITLE
Revert "Add ffaker dependency to gemspec"

### DIFF
--- a/solidus_gateway.gemspec
+++ b/solidus_gateway.gemspec
@@ -41,5 +41,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "poltergeist", "~> 1.9"
   s.add_development_dependency "database_cleaner", "~> 1.5"
-  s.add_development_dependency "ffaker"
 end


### PR DESCRIPTION
I missed that ffaker had already been added to the Gemfile. This reverts
d0e1852.