### PR TITLE
Remove deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 gem 'pg'
 gem 'mysql2'
+gem 'ffaker'
 
 group :development, :test do
   gem "pry-rails"

--- a/app/models/spree/gateway/authorize_net.rb
+++ b/app/models/spree/gateway/authorize_net.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::AuthorizeNet < Gateway
+  class Gateway::AuthorizeNet < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
 

--- a/app/models/spree/gateway/authorize_net.rb
+++ b/app/models/spree/gateway/authorize_net.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string
     preference :password, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::AuthorizeNetGateway
     end
 

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::AuthorizeNetCim < Gateway
+  class Gateway::AuthorizeNetCim < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
     preference :test_mode, :boolean, :default => false

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -5,7 +5,7 @@ module Spree
     preference :test_mode, :boolean, :default => false
     preference :validate_on_profile_create, :boolean, :default => false
 
-    def provider_class
+    def gateway_class
       self.class
     end
 

--- a/app/models/spree/gateway/balanced_gateway.rb
+++ b/app/models/spree/gateway/balanced_gateway.rb
@@ -8,12 +8,12 @@ module Spree
         # The Balanced ActiveMerchant gateway supports passing the token directly as the creditcard parameter
         creditcard = token
       end
-      provider.authorize(money, creditcard, gateway_options)
+      gateway.authorize(money, creditcard, gateway_options)
     end
 
     def capture(authorization, creditcard, gateway_options)
       gateway_options[:on_behalf_of_uri] = self.preferred_on_behalf_of_uri
-      provider.capture((authorization.amount * 100).round, authorization.response_code, gateway_options)
+      gateway.capture((authorization.amount * 100).round, authorization.response_code, gateway_options)
     end
 
     def create_profile(payment)
@@ -23,7 +23,7 @@ module Spree
       options[:email] = payment.order.email
       options[:login] = preferred_login
 
-      card_store_response = provider.store(payment.source, options)
+      card_store_response = gateway.store(payment.source, options)
       card_uri = card_store_response.authorization.split(';').first
 
       # A success just returns a string of the token. A failed request returns a bad request response with a message.
@@ -45,19 +45,19 @@ module Spree
         # The Balanced ActiveMerchant gateway supports passing the token directly as the creditcard parameter
         creditcard = token
       end
-      provider.purchase(money, creditcard, gateway_options)
+      gateway.purchase(money, creditcard, gateway_options)
     end
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::BalancedGateway
     end
 
     def credit(money, creditcard, response_code, gateway_options)
-      provider.refund(money, response_code, {})
+      gateway.refund(money, response_code, {})
     end
 
     def void(response_code, creditcard, gateway_options)
-      provider.void(response_code)
+      gateway.void(response_code)
     end
 
   end

--- a/app/models/spree/gateway/balanced_gateway.rb
+++ b/app/models/spree/gateway/balanced_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::BalancedGateway < Gateway
+  class Gateway::BalancedGateway < PaymentMethod::CreditCard
     preference :login, :string
     preference :on_behalf_of_uri, :string
 

--- a/app/models/spree/gateway/banwire.rb
+++ b/app/models/spree/gateway/banwire.rb
@@ -3,13 +3,13 @@ module Spree
     preference :login, :string
 
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::BanwireGateway
     end
 
     def purchase(money, creditcard, gateway_options)
       gateway_options[:description] = "Spree Order"
-      provider.purchase(money, creditcard, gateway_options)
+      gateway.purchase(money, creditcard, gateway_options)
     end
   end
 end

--- a/app/models/spree/gateway/banwire.rb
+++ b/app/models/spree/gateway/banwire.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Banwire < Gateway
+  class Gateway::Banwire < PaymentMethod::CreditCard
     preference :login, :string
 
 

--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Beanstream < Gateway
+  class Gateway::Beanstream < PaymentMethod::CreditCard
     preference :login, :string
     preference :user, :string
     preference :password, :string

--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -5,7 +5,7 @@ module Spree
     preference :password, :string
     preference :secure_profile_api_key, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::BeanstreamGateway
     end
 
@@ -18,7 +18,7 @@ module Spree
       if creditcard.gateway_customer_profile_id.nil?
         options = options_for_create_customer_profile(creditcard, {})
         verify_creditcard_name!(creditcard)
-        result = provider.store(creditcard, options)
+        result = gateway.store(creditcard, options)
         if result.success?
           creditcard.update_attributes(:gateway_customer_profile_id => result.params['customerCode'], :gateway_payment_profile_id => result.params['customer_vault_id'])
         else

--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::BraintreeGateway < Gateway
+  class Gateway::BraintreeGateway < PaymentMethod::CreditCard
     preference :environment, :string
     preference :merchant_id, :string
     preference :merchant_account_id, :string

--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -20,18 +20,18 @@ module Spree
       'Visa' => 'visa'
     }
 
-    def provider
-      provider_instance = super
+    def gateway
+      gateway_instance = super
       Braintree::Configuration.custom_user_agent = "solidus_gateway #{SolidusGateway::VERSION}"
       Braintree::Configuration.environment = preferred_environment.to_sym
       Braintree::Configuration.merchant_id = preferred_merchant_id
       Braintree::Configuration.public_key = preferred_public_key
       Braintree::Configuration.private_key = preferred_private_key
 
-      provider_instance
+      gateway_instance
     end
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::BraintreeBlueGateway
     end
 
@@ -45,16 +45,16 @@ module Spree
         payment_method = creditcard.gateway_customer_profile_id || creditcard
       end
 
-      provider.authorize(money, payment_method, options)
+      gateway.authorize(money, payment_method, options)
     end
 
     def capture(amount, authorization_code, ignored_options = {})
-      provider.capture(amount, authorization_code)
+      gateway.capture(amount, authorization_code)
     end
 
     def create_profile(payment)
       if payment.source.gateway_customer_profile_id.nil?
-        response = provider.store(payment.source, options_for_payment(payment))
+        response = gateway.store(payment.source, options_for_payment(payment))
 
         if response.success?
           payment.source.update_attributes!(:gateway_customer_profile_id => response.params['customer_vault_id'])
@@ -88,16 +88,16 @@ module Spree
 
     # Braintree now disables credits by default, see https://www.braintreepayments.com/docs/ruby/transactions/credit
     def credit_with_payment_profiles(amount, payment, response_code, option)
-      provider.credit(amount, payment)
+      gateway.credit(amount, payment)
     end
 
     def credit_without_payment_profiles(amount, response_code, options)
-      provider # braintree provider needs to be called here to properly configure braintree gem.
+      gateway # braintree provider needs to be called here to properly configure braintree gem.
       transaction = ::Braintree::Transaction.find(response_code)
       if BigDecimal.new(amount.to_s) == (transaction.amount * 100)
-        provider.refund(response_code)
+        gateway.refund(response_code)
       elsif BigDecimal.new(amount.to_s) < (transaction.amount * 100) # support partial refunds
-        provider.refund(amount, response_code)
+        gateway.refund(amount, response_code)
       else
         raise NotImplementedError
       end
@@ -112,7 +112,7 @@ module Spree
     end
 
     def void(response_code, *ignored_options)
-      provider.void(response_code)
+      gateway.void(response_code)
     end
 
     def options
@@ -126,15 +126,15 @@ module Spree
     end
 
     def cancel(response_code)
-      provider
+      gateway
       transaction = ::Braintree::Transaction.find(response_code)
       # From: https://www.braintreepayments.com/docs/ruby/transactions/refund
       # "A transaction can be refunded if its status is settled or settling.
       # If the transaction has not yet begun settlement, it should be voided instead of refunded.
       if transaction.status == Braintree::Transaction::Status::SubmittedForSettlement
-        provider.void(response_code)
+        gateway.void(response_code)
       else
-        provider.refund(response_code)
+        gateway.refund(response_code)
       end
     end
 

--- a/app/models/spree/gateway/card_save.rb
+++ b/app/models/spree/gateway/card_save.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::CardSave < Gateway
+  class Gateway::CardSave < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
 

--- a/app/models/spree/gateway/card_save.rb
+++ b/app/models/spree/gateway/card_save.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string
     preference :password, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::CardSaveGateway
     end
   end

--- a/app/models/spree/gateway/cardknox.rb
+++ b/app/models/spree/gateway/cardknox.rb
@@ -1,0 +1,9 @@
+module Spree
+  class Gateway::Cardknox < Gateway
+    preference :api_key, :string
+
+    def provider_class
+      ActiveMerchant::Billing::CardknoxGateway
+    end
+  end
+end

--- a/app/models/spree/gateway/cardknox.rb
+++ b/app/models/spree/gateway/cardknox.rb
@@ -1,9 +1,0 @@
-module Spree
-  class Gateway::Cardknox < Gateway
-    preference :api_key, :string
-
-    def provider_class
-      ActiveMerchant::Billing::CardknoxGateway
-    end
-  end
-end

--- a/app/models/spree/gateway/data_cash.rb
+++ b/app/models/spree/gateway/data_cash.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::DataCash < Gateway
+  class Gateway::DataCash < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
 

--- a/app/models/spree/gateway/data_cash.rb
+++ b/app/models/spree/gateway/data_cash.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string
     preference :password, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::DataCashGateway
     end
   end

--- a/app/models/spree/gateway/eway.rb
+++ b/app/models/spree/gateway/eway.rb
@@ -7,7 +7,7 @@ module Spree
       true
     end
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::EwayGateway
     end
 

--- a/app/models/spree/gateway/eway.rb
+++ b/app/models/spree/gateway/eway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Eway < Gateway
+  class Gateway::Eway < PaymentMethod::CreditCard
     preference :login, :string
 
     # Note: EWay supports purchase method only (no authorize method).

--- a/app/models/spree/gateway/linkpoint.rb
+++ b/app/models/spree/gateway/linkpoint.rb
@@ -10,7 +10,7 @@ module Spree
     [:authorize, :purchase, :capture, :void, :credit].each do |method|
       define_method(method) do |*args|
         options = add_discount_to_subtotal(args.extract_options!)
-        provider.public_send(method, *args << options)
+        gateway.public_send(method, *args << options)
       end
     end
 

--- a/app/models/spree/gateway/linkpoint.rb
+++ b/app/models/spree/gateway/linkpoint.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Linkpoint < Gateway
+  class Gateway::Linkpoint < PaymentMethod::CreditCard
     preference :login, :string
     preference :pem, :text
 

--- a/app/models/spree/gateway/linkpoint.rb
+++ b/app/models/spree/gateway/linkpoint.rb
@@ -3,14 +3,14 @@ module Spree
     preference :login, :string
     preference :pem, :text
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::LinkpointGateway
     end
 
     [:authorize, :purchase, :capture, :void, :credit].each do |method|
       define_method(method) do |*args|
         options = add_discount_to_subtotal(args.extract_options!)
-        provider.public_send(method, *args << options)
+        gateway.public_send(method, *args << options)
       end
     end
 

--- a/app/models/spree/gateway/linkpoint.rb
+++ b/app/models/spree/gateway/linkpoint.rb
@@ -10,7 +10,7 @@ module Spree
     [:authorize, :purchase, :capture, :void, :credit].each do |method|
       define_method(method) do |*args|
         options = add_discount_to_subtotal(args.extract_options!)
-        gateway.public_send(method, *args << options)
+        provider.public_send(method, *args << options)
       end
     end
 

--- a/app/models/spree/gateway/maxipago.rb
+++ b/app/models/spree/gateway/maxipago.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string # ID
     preference :password, :string # KEY
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::MaxipagoGateway
     end
 

--- a/app/models/spree/gateway/maxipago.rb
+++ b/app/models/spree/gateway/maxipago.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Maxipago < Gateway
+  class Gateway::Maxipago < PaymentMethod::CreditCard
     preference :login, :string # ID
     preference :password, :string # KEY
 

--- a/app/models/spree/gateway/migs.rb
+++ b/app/models/spree/gateway/migs.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Migs < Gateway
+  class Gateway::Migs < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
     preference :secure_hash, :string

--- a/app/models/spree/gateway/migs.rb
+++ b/app/models/spree/gateway/migs.rb
@@ -4,7 +4,7 @@ module Spree
     preference :password, :string
     preference :secure_hash, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::MigsGateway
     end
   end

--- a/app/models/spree/gateway/moneris.rb
+++ b/app/models/spree/gateway/moneris.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Moneris < Gateway
+  class Gateway::Moneris < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :password
 

--- a/app/models/spree/gateway/moneris.rb
+++ b/app/models/spree/gateway/moneris.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string
     preference :password, :password
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::MonerisGateway
     end
   end

--- a/app/models/spree/gateway/pay_junction.rb
+++ b/app/models/spree/gateway/pay_junction.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string
     preference :password, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::PayJunctionGateway
     end
 

--- a/app/models/spree/gateway/pay_junction.rb
+++ b/app/models/spree/gateway/pay_junction.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::PayJunction < Gateway
+  class Gateway::PayJunction < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
 

--- a/app/models/spree/gateway/pay_pal_gateway.rb
+++ b/app/models/spree/gateway/pay_pal_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::PayPalGateway < Gateway
+  class Gateway::PayPalGateway < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
     preference :signature, :string

--- a/app/models/spree/gateway/pay_pal_gateway.rb
+++ b/app/models/spree/gateway/pay_pal_gateway.rb
@@ -5,7 +5,7 @@ module Spree
     preference :signature, :string
     preference :currency_code, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::PaypalGateway
     end
   end

--- a/app/models/spree/gateway/payflow_pro.rb
+++ b/app/models/spree/gateway/payflow_pro.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::PayflowPro < Gateway
+  class Gateway::PayflowPro < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :password
     preference :partner, :string

--- a/app/models/spree/gateway/payflow_pro.rb
+++ b/app/models/spree/gateway/payflow_pro.rb
@@ -4,7 +4,7 @@ module Spree
     preference :password, :password
     preference :partner, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::PayflowGateway
     end
 

--- a/app/models/spree/gateway/paymill.rb
+++ b/app/models/spree/gateway/paymill.rb
@@ -5,7 +5,7 @@ module Spree
     preference :private_key, :string
     preference :currency, :string, :default => 'GBP'
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::PaymillGateway
     end
   end

--- a/app/models/spree/gateway/paymill.rb
+++ b/app/models/spree/gateway/paymill.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Paymill < Gateway
+  class Gateway::Paymill < PaymentMethod::CreditCard
 
     preference :public_key, :string
     preference :private_key, :string

--- a/app/models/spree/gateway/pin_gateway.rb
+++ b/app/models/spree/gateway/pin_gateway.rb
@@ -3,7 +3,7 @@ module Spree
     preference :api_key, :string
     preference :currency, :string, :default => 'AUD'
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::PinGateway
     end
     
@@ -13,7 +13,7 @@ module Spree
     
     def create_profile(payment)
       if payment.source.gateway_customer_profile_id.nil?
-        response = provider.store(payment.source, options_for_payment(payment))
+        response = gateway.store(payment.source, options_for_payment(payment))
         
         if response.success?
           payment.source.update_attributes!(:gateway_customer_profile_id => response.authorization)

--- a/app/models/spree/gateway/pin_gateway.rb
+++ b/app/models/spree/gateway/pin_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::PinGateway < Gateway
+  class Gateway::PinGateway < PaymentMethod::CreditCard
     preference :api_key, :string
     preference :currency, :string, :default => 'AUD'
 

--- a/app/models/spree/gateway/sage_pay.rb
+++ b/app/models/spree/gateway/sage_pay.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::SagePay < Gateway
+  class Gateway::SagePay < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
     preference :account, :string

--- a/app/models/spree/gateway/sage_pay.rb
+++ b/app/models/spree/gateway/sage_pay.rb
@@ -4,7 +4,7 @@ module Spree
     preference :password, :string
     preference :account, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::SagePayGateway
     end
   end

--- a/app/models/spree/gateway/secure_pay_au.rb
+++ b/app/models/spree/gateway/secure_pay_au.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::SecurePayAU < Gateway
+  class Gateway::SecurePayAU < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
 

--- a/app/models/spree/gateway/secure_pay_au.rb
+++ b/app/models/spree/gateway/secure_pay_au.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string
     preference :password, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::SecurePayAuGateway
     end
   end

--- a/app/models/spree/gateway/spreedly_core_gateway.rb
+++ b/app/models/spree/gateway/spreedly_core_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::SpreedlyCoreGateway < Gateway
+  class Gateway::SpreedlyCoreGateway < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
     preference :gateway_token, :string

--- a/app/models/spree/gateway/spreedly_core_gateway.rb
+++ b/app/models/spree/gateway/spreedly_core_gateway.rb
@@ -3,7 +3,7 @@ module Spree
     preference :login, :string
     preference :password, :string
     preference :gateway_token, :string
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::SpreedlyCoreGateway
     end
   end

--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::StripeGateway < Gateway
+  class Gateway::StripeGateway < PaymentMethod::CreditCard
     preference :secret_key, :string
     preference :publishable_key, :string
 

--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -19,7 +19,7 @@ module Spree
       end
     end
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::StripeGateway
     end
 

--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -28,27 +28,27 @@ module Spree
     end
 
     def purchase(money, creditcard, gateway_options)
-      provider.purchase(*options_for_purchase_or_auth(money, creditcard, gateway_options))
+      gateway.purchase(*options_for_purchase_or_auth(money, creditcard, gateway_options))
     end
 
     def authorize(money, creditcard, gateway_options)
-      provider.authorize(*options_for_purchase_or_auth(money, creditcard, gateway_options))
+      gateway.authorize(*options_for_purchase_or_auth(money, creditcard, gateway_options))
     end
 
     def capture(money, response_code, gateway_options)
-      provider.capture(money, response_code, gateway_options)
+      gateway.capture(money, response_code, gateway_options)
     end
 
     def credit(money, creditcard, response_code, gateway_options)
-      provider.refund(money, response_code, {})
+      gateway.refund(money, response_code, {})
     end
 
     def void(response_code, creditcard, gateway_options)
-      provider.void(response_code, {})
+      gateway.void(response_code, {})
     end
 
     def cancel(response_code)
-      provider.void(response_code, {})
+      gateway.void(response_code, {})
     end
 
     def create_profile(payment)
@@ -65,7 +65,7 @@ module Spree
         creditcard = source
       end
 
-      response = provider.store(creditcard, options)
+      response = gateway.store(creditcard, options)
       if response.success?
         payment.source.update_attributes!({
           cc_type: payment.source.cc_type, # side-effect of update_source!

--- a/app/models/spree/gateway/usa_epay.rb
+++ b/app/models/spree/gateway/usa_epay.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::UsaEpay < Gateway
+  class Gateway::UsaEpay < PaymentMethod::CreditCard
     preference :login, :string
 
     def provider_class

--- a/app/models/spree/gateway/usa_epay.rb
+++ b/app/models/spree/gateway/usa_epay.rb
@@ -2,7 +2,7 @@ module Spree
   class Gateway::UsaEpay < PaymentMethod::CreditCard
     preference :login, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::UsaEpayGateway
     end
   end

--- a/app/models/spree/gateway/worldpay.rb
+++ b/app/models/spree/gateway/worldpay.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::Worldpay < Gateway
+  class Gateway::Worldpay < PaymentMethod::CreditCard
     preference :login, :string
     preference :password, :string
     preference :currency, :string, :default => 'GBP'

--- a/app/models/spree/gateway/worldpay.rb
+++ b/app/models/spree/gateway/worldpay.rb
@@ -12,28 +12,28 @@ module Spree
     preference :maestro_login, :string
     preference :visa_login, :string
 
-    def provider_class
+    def gateway_class
       ActiveMerchant::Billing::WorldpayGateway
     end
 
     def purchase(money, credit_card, options = {})
-      provider = credit_card_provider(credit_card, options)
-      provider.purchase(money, credit_card, options)
+      gateway = credit_card_provider(credit_card, options)
+      gateway.purchase(money, credit_card, options)
     end
 
     def authorize(money, credit_card, options = {})
-      provider = credit_card_provider(credit_card, options)
-      provider.authorize(money, credit_card, options)
+      gateway = credit_card_provider(credit_card, options)
+      gateway.authorize(money, credit_card, options)
     end
 
     def capture(money, authorization, options = {})
-      provider = credit_card_provider(auth_credit_card(authorization), options)
-      provider.capture(money, authorization, options)
+      gateway = credit_card_provider(auth_credit_card(authorization), options)
+      gateway.capture(money, authorization, options)
     end
 
     def refund(money, authorization, options = {})
-      provider = credit_card_provider(auth_credit_card(authorization), options)
-      provider.refund(money, authorization, options)
+      gateway = credit_card_provider(auth_credit_card(authorization), options)
+      gateway.refund(money, authorization, options)
     end
 
     def credit(money, authorization, options = {})
@@ -41,8 +41,8 @@ module Spree
     end
 
     def void(authorization, options = {})
-      provider = credit_card_provider(auth_credit_card(authorization), options)
-      provider.void(authorization, options)
+      gateway = credit_card_provider(auth_credit_card(authorization), options)
+      gateway.void(authorization, options)
     end
 
     private
@@ -62,7 +62,7 @@ module Spree
       gateway_options[:currency] = self.preferred_currency
       gateway_options[:inst_id] = self.preferred_installation_id
       ActiveMerchant::Billing::Base.gateway_mode = gateway_options[:server].to_sym
-      @provider = provider_class.new(gateway_options)
+      @gateway = gateway_class.new(gateway_options)
     end
 
     def login_for_card(card)

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -18,6 +18,7 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::Worldpay
         app.config.spree.payment_methods << Spree::Gateway::Banwire
         app.config.spree.payment_methods << Spree::Gateway::UsaEpay
+        app.config.spree.payment_methods << Spree::Gateway::Cardknox
         app.config.spree.payment_methods << Spree::Gateway::BalancedGateway
         app.config.spree.payment_methods << Spree::Gateway::DataCash
         app.config.spree.payment_methods << Spree::Gateway::PinGateway

--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -18,7 +18,6 @@ module SpreeGateway
         app.config.spree.payment_methods << Spree::Gateway::Worldpay
         app.config.spree.payment_methods << Spree::Gateway::Banwire
         app.config.spree.payment_methods << Spree::Gateway::UsaEpay
-        app.config.spree.payment_methods << Spree::Gateway::Cardknox
         app.config.spree.payment_methods << Spree::Gateway::BalancedGateway
         app.config.spree.payment_methods << Spree::Gateway::DataCash
         app.config.spree.payment_methods << Spree::Gateway::PinGateway

--- a/spec/models/gateway/authorize_net_cim_spec.rb
+++ b/spec/models/gateway/authorize_net_cim_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::AuthorizeNetCim do
   let (:gateway) { described_class.new }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a AuthorizeNetCim gateway' do
-      expect(gateway.provider_class).to eq ::Spree::Gateway::AuthorizeNetCim
+      expect(gateway.gateway_class).to eq ::Spree::Gateway::AuthorizeNetCim
     end
   end
 

--- a/spec/models/gateway/authorize_net_spec.rb
+++ b/spec/models/gateway/authorize_net_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::AuthorizeNet do
   let (:gateway) { described_class.create!(name: 'Authorize.net') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a AuthorizeNet gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::AuthorizeNetGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::AuthorizeNetGateway
     end
   end
 

--- a/spec/models/gateway/balanced_gateway_spec.rb
+++ b/spec/models/gateway/balanced_gateway_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::BalancedGateway do
   let(:gateway) { described_class.create!(name: 'Balanced') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Balanced gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::BalancedGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::BalancedGateway
     end
   end
 

--- a/spec/models/gateway/banwire_spec.rb
+++ b/spec/models/gateway/banwire_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::Banwire do
   let(:gateway) { described_class.create!(name: 'Banwire') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Banwire gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::BanwireGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::BanwireGateway
     end
   end
 end

--- a/spec/models/gateway/beanstream_spec.rb
+++ b/spec/models/gateway/beanstream_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::Beanstream do
   let(:gateway) { described_class.create!(name: 'Beanstream') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Beanstream gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::BeanstreamGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::BeanstreamGateway
     end
   end
 

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -158,9 +158,9 @@ describe Spree::Gateway::BraintreeGateway do
     end
   end
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a BraintreeBlue gateway' do
-      expect(@gateway.provider_class).to eq ::ActiveMerchant::Billing::BraintreeBlueGateway
+      expect(@gateway.gateway_class).to eq ::ActiveMerchant::Billing::BraintreeBlueGateway
     end
   end
 
@@ -426,7 +426,7 @@ describe Spree::Gateway::BraintreeGateway do
     end
     yield
   ensure
-    Spree::Gateway::BraintreeGateway.class_eval do
+   Spree::Gateway::BraintreeGateway.class_eval do
       def payment_profiles_supported?
         true
       end

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -30,7 +30,7 @@ describe Spree::Gateway::BraintreeGateway do
       )
 
       order = create(:order_with_totals, bill_address: address, ship_address: address)
-      order.update!
+      order.recalculate
 
       # Use a valid CC from braintree sandbox: https://www.braintreepayments.com/docs/ruby/reference/sandbox
 

--- a/spec/models/gateway/braintree_gateway_spec.rb
+++ b/spec/models/gateway/braintree_gateway_spec.rb
@@ -64,7 +64,7 @@ describe Spree::Gateway::BraintreeGateway do
       @address = address
 
       order = create(:order_with_totals, bill_address: address, ship_address: address)
-      order.update!
+      order.recalculate
 
       @credit_card = create(:credit_card,
         verification_value: '123',
@@ -79,7 +79,7 @@ describe Spree::Gateway::BraintreeGateway do
 
     context 'when a credit card is created' do
       it 'it has the address associated on the remote payment profile' do
-        remote_customer = @gateway.provider.instance_variable_get(:@braintree_gateway).customer.find(@credit_card.gateway_customer_profile_id)
+        remote_customer = @gateway.gateway.instance_variable_get(:@braintree_gateway).customer.find(@credit_card.gateway_customer_profile_id)
         remote_address = remote_customer.addresses.first rescue nil
         expect(remote_address).not_to be_nil
         expect(remote_address.street_address).to eq(@address.address1)
@@ -111,7 +111,7 @@ describe Spree::Gateway::BraintreeGateway do
       @address = address
 
       @order = create(:order_with_totals, bill_address: address, ship_address: address)
-      @order.update!
+      @order.recalculate
 
       @credit_card = create(:credit_card,
         verification_value: '123',
@@ -182,8 +182,8 @@ describe Spree::Gateway::BraintreeGateway do
         @credit_card.update_attributes(gateway_payment_profile_id: 'test')
       end
 
-      it 'calls provider#authorize using the gateway_payment_profile_id' do
-        expect(@gateway.provider).to receive(:authorize).with(500, 'test', { payment_method_token: true } )
+      it 'calls gateway#authorize using the gateway_payment_profile_id' do
+        expect(@gateway.gateway).to receive(:authorize).with(500, 'test', { payment_method_token: true } )
         @gateway.authorize(500, @credit_card)
       end
     end
@@ -194,15 +194,15 @@ describe Spree::Gateway::BraintreeGateway do
           @credit_card.update_attributes(gateway_customer_profile_id: '12345')
         end
 
-        it 'calls provider#authorize using the gateway_customer_profile_id' do
-          expect(@gateway.provider).to receive(:authorize).with(500, '12345', {})
+        it 'calls gateway#authorize using the gateway_customer_profile_id' do
+          expect(@gateway.gateway).to receive(:authorize).with(500, '12345', {})
           @gateway.authorize(500, @credit_card)
         end
       end
 
       context "no customer profile id" do
-        it 'calls provider#authorize with the credit card object' do
-          expect(@gateway.provider).to receive(:authorize).with(500, @credit_card, {})
+        it 'calls gateway#authorize with the credit card object' do
+          expect(@gateway.gateway).to receive(:authorize).with(500, @credit_card, {})
           @gateway.authorize(500, @credit_card)
         end
       end

--- a/spec/models/gateway/card_save_spec.rb
+++ b/spec/models/gateway/card_save_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::CardSave do
   let(:gateway) { described_class.create!(name: 'CardSave') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a CardSave gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::CardSaveGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::CardSaveGateway
     end
   end
 end

--- a/spec/models/gateway/data_cache_spec.rb
+++ b/spec/models/gateway/data_cache_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::DataCash do
   let(:gateway) { described_class.create!(name: 'DataCash') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a DataCash gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::DataCashGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::DataCashGateway
     end
   end
 end

--- a/spec/models/gateway/eway_spec.rb
+++ b/spec/models/gateway/eway_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::Eway do
   let(:gateway) { described_class.create!(name: 'Eway') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Eway gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::EwayGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::EwayGateway
     end
   end
 

--- a/spec/models/gateway/linkpoint_spec.rb
+++ b/spec/models/gateway/linkpoint_spec.rb
@@ -9,12 +9,12 @@ describe Spree::Gateway::Linkpoint do
   let(:options) { { subtotal: 3, discount: -1 } }
 
   before do
-    allow(gateway.provider_class).to receive_messages(new: provider)
+    allow(gateway.gateway_class).to receive_messages(new: provider)
   end
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Linkpoint gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::LinkpointGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::LinkpointGateway
     end
   end
 

--- a/spec/models/gateway/maxipago_spec.rb
+++ b/spec/models/gateway/maxipago_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::Maxipago do
   let(:gateway) { described_class.create!(name: 'Maxipago') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Maxipago gateway' do
-      expect(subject.provider_class).to eq ::ActiveMerchant::Billing::MaxipagoGateway
+      expect(subject.gateway_class).to eq ::ActiveMerchant::Billing::MaxipagoGateway
     end
   end
 

--- a/spec/models/gateway/moneris_spec.rb
+++ b/spec/models/gateway/moneris_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::Moneris do
   let(:gateway) { described_class.create!(name: 'Moneris') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Moneris gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::MonerisGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::MonerisGateway
     end
   end
 end

--- a/spec/models/gateway/pay_junction_spec.rb
+++ b/spec/models/gateway/pay_junction_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::PayJunction do
   let(:gateway) { described_class.create!(name: 'PayJunction') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a PayJunction gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::PayJunctionGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::PayJunctionGateway
     end
   end
 

--- a/spec/models/gateway/pay_pal_spec.rb
+++ b/spec/models/gateway/pay_pal_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::PayPalGateway do
   let(:gateway) { described_class.create!(name: 'PayPal') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a PayPal gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::PaypalGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::PaypalGateway
     end
   end
 end

--- a/spec/models/gateway/payflow_pro_spec.rb
+++ b/spec/models/gateway/payflow_pro_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::PayflowPro do
   let(:gateway) { described_class.create!(name: 'PayflowPro') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Payflow gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::PayflowGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::PayflowGateway
     end
   end
 

--- a/spec/models/gateway/paymill_spec.rb
+++ b/spec/models/gateway/paymill_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::Paymill do
   let(:gateway) { described_class.create!(name: 'Paymill') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Paymill gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::PaymillGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::PaymillGateway
     end
   end
 end

--- a/spec/models/gateway/pin_gateway_spec.rb
+++ b/spec/models/gateway/pin_gateway_spec.rb
@@ -23,7 +23,7 @@ describe Spree::Gateway::PinGateway do
     )
 
     order = create(:order_with_totals, bill_address: address, ship_address: address)
-    order.update!
+    order.recalculate
 
     credit_card = create(:credit_card,
       verification_value: '123',

--- a/spec/models/gateway/sage_pay_spec.rb
+++ b/spec/models/gateway/sage_pay_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::SagePay do
   let(:gateway) { described_class.create!(name: 'SagePay') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a SagePay gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::SagePayGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::SagePayGateway
     end
   end
 end

--- a/spec/models/gateway/secure_pay_au_spec.rb
+++ b/spec/models/gateway/secure_pay_au_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::SecurePayAU do
   let(:gateway) { described_class.create!(name: 'SecurePayAU') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a SecurePayAU gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::SecurePayAuGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::SecurePayAuGateway
     end
   end
 end

--- a/spec/models/gateway/stripe_gateway_spec.rb
+++ b/spec/models/gateway/stripe_gateway_spec.rb
@@ -15,8 +15,8 @@ describe Spree::Gateway::StripeGateway do
     )
   }
 
-  let(:provider) do
-    double('provider').tap do |p|
+  let(:gateway) do
+    double('gateway').tap do |p|
       allow(p).to receive(:purchase)
       allow(p).to receive(:authorize)
       allow(p).to receive(:capture)
@@ -26,7 +26,7 @@ describe Spree::Gateway::StripeGateway do
   before do
     subject.preferences = { secret_key: secret_key }
     allow(subject).to receive(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
-    allow(subject).to receive(:provider).and_return provider
+    allow(subject).to receive(:gateway).and_return gateway
   end
 
   describe '#create_profile' do
@@ -46,8 +46,8 @@ describe Spree::Gateway::StripeGateway do
         )
       }
 
-      it 'stores the bill address with the provider' do
-        expect(subject.provider).to receive(:store).with(payment.source, {
+      it 'stores the bill address with the gateway' do
+        expect(subject.gateway).to receive(:store).with(payment.source, {
           email: email,
           login: secret_key,
 
@@ -68,8 +68,8 @@ describe Spree::Gateway::StripeGateway do
     context 'with an order that does not have a bill address' do
       let(:bill_address) { nil }
 
-      it 'does not store a bill address with the provider' do
-        expect(subject.provider).to receive(:store).with(payment.source, {
+      it 'does not store a bill address with the gateway' do
+        expect(subject.gateway).to receive(:store).with(payment.source, {
           email: email,
           login: secret_key,
         }).and_return double.as_null_object
@@ -81,7 +81,7 @@ describe Spree::Gateway::StripeGateway do
       context "correcting the card type" do
         before do
           # We don't care about this method for these tests
-          allow(subject.provider).to receive(:store).and_return(double.as_null_object)
+          allow(subject.gateway).to receive(:store).and_return(double.as_null_object)
         end
 
         it "converts 'American Express' to 'american_express'" do
@@ -109,7 +109,7 @@ describe Spree::Gateway::StripeGateway do
       let(:bill_address) { nil }
 
       it 'stores the profile_id as a card' do
-        expect(subject.provider).to receive(:store).with(source.gateway_payment_profile_id, anything).and_return double.as_null_object
+        expect(subject.gateway).to receive(:store).with(source.gateway_payment_profile_id, anything).and_return double.as_null_object
 
         subject.create_profile payment
       end
@@ -121,8 +121,8 @@ describe Spree::Gateway::StripeGateway do
       subject.purchase(19.99, 'credit card', {})
     end
 
-    it 'send the payment to the provider' do
-      expect(provider).to receive(:purchase).with('money','cc','opts')
+    it 'send the payment to the gateway' do
+      expect(gateway).to receive(:purchase).with('money','cc','opts')
     end
   end
 
@@ -131,8 +131,8 @@ describe Spree::Gateway::StripeGateway do
       subject.authorize(19.99, 'credit card', {})
     end
 
-    it 'send the authorization to the provider' do
-      expect(provider).to receive(:authorize).with('money','cc','opts')
+    it 'send the authorization to the gateway' do
+      expect(gateway).to receive(:authorize).with('money','cc','opts')
     end
   end
 
@@ -143,11 +143,11 @@ describe Spree::Gateway::StripeGateway do
     end
 
     it 'convert the amount to cents' do
-      expect(provider).to receive(:capture).with(1234,anything,anything)
+      expect(gateway).to receive(:capture).with(1234,anything,anything)
     end
 
     it 'use the response code as the authorization' do
-      expect(provider).to receive(:capture).with(anything,'response_code',anything)
+      expect(gateway).to receive(:capture).with(anything,'response_code',anything)
     end
   end
 
@@ -156,7 +156,7 @@ describe Spree::Gateway::StripeGateway do
       gateway = described_class.new(:active => true)
       gateway.set_preference :secret_key, secret_key
       allow(gateway).to receive(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
-      allow(gateway).to receive(:provider).and_return provider
+      allow(gateway).to receive(:gateway).and_return gateway
       allow(gateway).to receive_messages :source_required => true
       gateway
     end
@@ -195,7 +195,7 @@ describe Spree::Gateway::StripeGateway do
     end
 
     it 'gets correct amount' do
-      expect(provider).to receive(:capture).with(9855,'12345',anything).and_return(success_response)
+      expect(gateway).to receive(:capture).with(9855,'12345',anything).and_return(success_response)
     end
   end
 end

--- a/spec/models/gateway/usa_epay_spec.rb
+++ b/spec/models/gateway/usa_epay_spec.rb
@@ -21,7 +21,7 @@ describe Spree::Gateway::UsaEpay do
       country:   country)
 
     order = create(:order_with_totals, bill_address: address, ship_address: address)
-    order.update!
+    order.recalculate
 
     credit_card = create(:credit_card,
       verification_value: '123',

--- a/spec/models/gateway/usa_epay_spec.rb
+++ b/spec/models/gateway/usa_epay_spec.rb
@@ -40,9 +40,9 @@ describe Spree::Gateway::UsaEpay do
     end
   end
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Worldpay gateway' do
-      expect(@gateway.provider_class).to eq ::ActiveMerchant::Billing::UsaEpayGateway
+      expect(@gateway.gateway_class).to eq ::ActiveMerchant::Billing::UsaEpayGateway
     end
   end
 end

--- a/spec/models/gateway/worldpay_spec.rb
+++ b/spec/models/gateway/worldpay_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Spree::Gateway::Worldpay do
   let(:gateway) { described_class.create!(name: 'Worldpay') }
 
-  context '.provider_class' do
+  context '.gateway_class' do
     it 'is a Worldpay gateway' do
-      expect(gateway.provider_class).to eq ::ActiveMerchant::Billing::WorldpayGateway
+      expect(gateway.gateway_class).to eq ::ActiveMerchant::Billing::WorldpayGateway
     end
   end
 end


### PR DESCRIPTION
I went through all of the gateways and updated them to remove all the deprecation warnings that used to come up by testing.

As a side effect, I believe the tests run about a minute faster now.