### PR TITLE
require active_merchant to initialize gateway providers

### DIFF
--- a/app/models/spree/gateway/authorize_net.rb
+++ b/app/models/spree/gateway/authorize_net.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/gateways/authorize_net'
+
 module Spree
   class Gateway::AuthorizeNet < Gateway
     preference :login, :string

--- a/app/models/spree/gateway/authorize_net_cim.rb
+++ b/app/models/spree/gateway/authorize_net_cim.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/gateways/authorize_net_cim'
+
 module Spree
   class Gateway::AuthorizeNetCim < Gateway
     preference :login, :string

--- a/app/models/spree/gateway/banwire.rb
+++ b/app/models/spree/gateway/banwire.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/gateways/banwire'
+
 module Spree
   class Gateway::Banwire < Gateway
     preference :login, :string

--- a/app/models/spree/gateway/beanstream.rb
+++ b/app/models/spree/gateway/beanstream.rb
@@ -1,3 +1,6 @@
+require 'active_merchant/billing/gateways/beanstream/beanstream_core'
+require 'active_merchant/billing/gateways/beanstream'
+
 module Spree
   class Gateway::Beanstream < Gateway
     preference :login, :string

--- a/app/models/spree/gateway/braintree_gateway.rb
+++ b/app/models/spree/gateway/braintree_gateway.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/gateways/braintree_blue'
+
 module Spree
   class Gateway::BraintreeGateway < Gateway
     preference :environment, :string

--- a/app/models/spree/gateway/card_save.rb
+++ b/app/models/spree/gateway/card_save.rb
@@ -1,3 +1,6 @@
+require 'active_merchant/billing/gateways/iridium'
+require 'active_merchant/billing/gateways/card_save'
+
 module Spree
   class Gateway::CardSave < Gateway
     preference :login, :string

--- a/app/models/spree/gateway/data_cash.rb
+++ b/app/models/spree/gateway/data_cash.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/gateways/data_cash'
+
 module Spree
   class Gateway::DataCash < Gateway
     preference :login, :string

--- a/app/models/spree/gateway/linkpoint.rb
+++ b/app/models/spree/gateway/linkpoint.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/gateways/linkpoint'
+
 module Spree
   class Gateway::Linkpoint < Gateway
     preference :login, :string

--- a/app/models/spree/gateway/pin_gateway.rb
+++ b/app/models/spree/gateway/pin_gateway.rb
@@ -1,3 +1,5 @@
+require 'active_merchant/billing/gateways/pin'
+
 module Spree
   class Gateway::PinGateway < Gateway
     preference :api_key, :string

--- a/lib/solidus_gateway.rb
+++ b/lib/solidus_gateway.rb
@@ -1,5 +1,6 @@
 require "solidus_core"
 require "solidus_support"
+require "active_merchant"
 require "spree_gateway/engine"
 require "solidus_gateway/version"
 require "sass/rails"

--- a/lib/solidus_gateway.rb
+++ b/lib/solidus_gateway.rb
@@ -1,6 +1,11 @@
 require "solidus_core"
 require "solidus_support"
-require "active_merchant"
+require 'active_merchant/empty'
+require 'active_merchant/network_connection_retries'
+require 'active_merchant/connection'
+require 'active_merchant/posts_data'
+require 'active_merchant/country'
+require 'active_merchant/billing/gateway'
 require "spree_gateway/engine"
 require "solidus_gateway/version"
 require "sass/rails"


### PR DESCRIPTION
Since https://github.com/solidusio/solidus/commit/6a296d55c0f6096a823946cb8365ff264c47ad98 just specific parts from `active_merchant` is required in core.

So, build with master is failing when are trying to monkey patch `ActiveMerchant::Billing::BeantreamGateway`.

Requiring `active_merchant` in the gem fix the problem.