### PR TITLE
Update README for outdated RubyGems version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ In your Gemfile:
 gem "solidus_gateway"
 ```
 
+If you are running Solidus >= 2.5.x, you'll need the git reference in your Gemfile to ensure `master` is used:
+
+```ruby
+gem "solidus_gateway", git: 'https://github.com/solidusio/solidus_gateway.git'
+```
+
 Then run from the command line:
 
 ```shell


### PR DESCRIPTION
This is a small change to the documentation, specifying the use of a `git:` reference in the Gemfile.

The current RubyGems source is outdated; in order to be used with Solidus 2.5, we need the master branch of solidus_gateway, which contains the latest fixes.