### PR TITLE
Fix Travis issue with Solidus old versions (Factory Bot gem)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,14 +16,23 @@ else
   gem "rails", "~> 4.2.10"
 end
 
-gem 'pg', '~> 0.21'
-gem 'mysql2', '~> 0.4.10'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 gem 'chromedriver-helper' if ENV['CI']
 
 group :development, :test do
   gem "pry-rails"
   gem "ffaker"
+
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 gemspec

--- a/solidus_gateway.gemspec
+++ b/solidus_gateway.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.2"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "factory_bot", "~> 4.4"
   s.add_development_dependency "capybara", "~> 2.18"
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "poltergeist", "~> 1.9"


### PR DESCRIPTION
For Solidus versions older than `v2.5` gem `factory_bot 4.10.0` must be used
for compatibility reasons.