### PR TITLE
Add missing API partial for stripe gateway

### DIFF
--- a/lib/spree_gateway/engine.rb
+++ b/lib/spree_gateway/engine.rb
@@ -49,5 +49,9 @@ module SpreeGateway
     if SolidusSupport.frontend_available?
       paths["app/views"] << "lib/views/frontend"
     end
+
+    if SolidusSupport.api_available?
+      paths["app/views"] << "lib/views/api"
+    end
   end
 end

--- a/lib/views/api/spree/api/payments/source_views/_stripe.json.jbuilder
+++ b/lib/views/api/spree/api/payments/source_views/_stripe.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial!('spree/api/payments/source_views/gateway', payment_source: payment_source)


### PR DESCRIPTION
Solves https://github.com/solidusio/solidus/issues/2833

As the discussion in that issue states, I'm aware `solidus_stripe` is recommended over `solidus_gateway` but this partial is nowhere to be found in any of both repositories (I'll create a PR there as well if this is approved).

I was wondering if these comments and/or any documentation needs to be updated to include such API partials as part of what the payment methods need to provide.
https://github.com/solidusio/solidus/blob/master/core/app/models/spree/payment_method.rb#L184